### PR TITLE
Clean-up perceptron api and serialization

### DIFF
--- a/NeuralNetwork/BackPropagation/BPContext.h
+++ b/NeuralNetwork/BackPropagation/BPContext.h
@@ -25,12 +25,8 @@ struct BPContext< Var, std::tuple< Layers... > > {
 
 template< typename Archive, typename Var, typename... Layers >
 void serialize(Archive& ar, BPContext< Var, std::tuple< Layers... > >& ctx) {
-    ar(cereal::make_nvp("outputs", ctx.outputs));
     ar(cereal::make_nvp("weights", ctx.weights));
     ar(cereal::make_nvp("biases", ctx.biases));
-    ar(cereal::make_nvp("deltas", ctx.deltas));
-    ar(cereal::make_nvp("biasGradients", ctx.biasGradients));
-    ar(cereal::make_nvp("weightGradients", ctx.weightGradients));
 }
 
 } // namespace nn::bp

--- a/NeuralNetwork/Perceptron/ComplexLayer.h
+++ b/NeuralNetwork/Perceptron/ComplexLayer.h
@@ -30,14 +30,14 @@ namespace nn {
 
         template< typename Layer >
         void calculateOutputs(Layer& nextLayer) {
-            m_perceptron.calculate(m_inputs.begin(), m_inputs.end(), m_outputs.begin());
+            m_perceptron.evaluate(m_inputs.begin(), m_inputs.end(), m_outputs.begin());
             for(std::size_t i = 0; i < m_outputs.size(); i++) {
                 nextLayer.setInput(i, m_outputs[i]);
             }
         }
 
         void calculateOutputs() {
-            m_perceptron.calculate(m_inputs.begin(), m_inputs.end(), m_outputs.begin());
+            m_perceptron.evaluate(m_inputs.begin(), m_inputs.end(), m_outputs.begin());
         }
 
         auto begin() const {

--- a/NeuralNetwork/Perceptron/Perceptron.h
+++ b/NeuralNetwork/Perceptron/Perceptron.h
@@ -57,7 +57,7 @@ namespace nn {
             using use = decltype(perceptron< T >(std::declval< Layers >()));
 
             using Input = typename InputLayerType::Input;
-            using Context = std::tuple<std::array<Var, L::size()>...>;
+            using Context = std::tuple< std::array< Var, L::size() >... >;
 
           private:
             Layers m_layers;
@@ -81,14 +81,14 @@ namespace nn {
             }
 
             /*!
-             * @brief this method will calculate the outputs of perceptron.
+             * @brief this method will evaluate the outputs of perceptron.
              * @param begin is the iterator which is pointing to the first input
              * @param end the iterator which is pointing to the last input
              * @param out the output iterator where the results of the
-             * calculation will be stored.
+             * evaluation will be stored.
              */
             template< typename Iterator, typename OutputIterator >
-            void calculate(Iterator begin, Iterator end, OutputIterator out) {
+            void evaluate(Iterator begin, Iterator end, OutputIterator out) {
                 auto& inputLayer = std::get< 0 >(m_layers);
                 unsigned int inputId = 0;
                 while(begin != end) {
@@ -107,7 +107,8 @@ namespace nn {
 
                 utils::for_< size() - 1U >([this](auto i) {
                     auto& layer = utils::get< i.value + 1 >(m_layers);
-                    layer.template calculateOutputs< decltype(m_context), i.value + 1, i.value >(m_context);
+                    layer.template calculateOutputs< decltype(m_context), i.value + 1, i.value >(
+                     m_context);
                 });
 
                 auto& outputCtx = std::get< size() - 1U >(m_context);

--- a/SystemTests/PerceptronTest.cpp
+++ b/SystemTests/PerceptronTest.cpp
@@ -44,7 +44,7 @@ namespace {
                 input[2] = Input{{{0.2f, 0.0f}}};
 
                 std::array< float, 1 > output{0.f};
-                perceptron.calculate(input.begin(), input.end(), output.begin());
+                perceptron.evaluate(input.begin(), input.end(), output.begin());
 
                 float n0 = 1.0f / (1.0f + std::exp(-2.0f));
                 float n1 = 1.0f / (1.0f + std::exp(-0.5f));
@@ -64,7 +64,7 @@ namespace {
                 input[2] = typename TestPerceptron::Input{{{0.1f, 0.1f}}};
 
                 std::array< float, 1 > output{0.f};
-                perceptron.calculate(input.begin(), input.end(), output.begin());
+                perceptron.evaluate(input.begin(), input.end(), output.begin());
 
                 THEN("Output should sum all input values through sigmoid") {
                     float n0 = 1.0f / (1.0f + std::exp(-10.0f));


### PR DESCRIPTION
rename calculate to evaluate api. Clean up serialization, no need to serialize outputs